### PR TITLE
Add offline startup test without network access

### DIFF
--- a/tests/test_offline_startup.py
+++ b/tests/test_offline_startup.py
@@ -1,0 +1,61 @@
+import importlib
+import sys
+import socket
+
+
+def _block_network(*args, **kwargs):
+    raise OSError("Network access is disabled for this test")
+
+
+def test_app_starts_and_serves_without_network(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.setattr(socket, "create_connection", _block_network)
+    monkeypatch.setattr(socket, "getaddrinfo", _block_network)
+    monkeypatch.setattr(socket.socket, "connect", _block_network)
+    monkeypatch.setattr(socket.socket, "connect_ex", _block_network)
+
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+    flask_app = app_module.app
+
+    client = flask_app.test_client()
+
+    health_response = client.get("/health")
+    assert health_response.status_code == 200
+
+    payload = {
+        "stories": [
+            {
+                "id": "offline-startup-test-story-1",
+                "tags": {
+                    "APT28": {"name": "APT28", "tag_type": "APT"},
+                    "CVE-2024-1234": {"name": "CVE-2024-1234", "tag_type": "cves"},
+                    "Microsoft": {"name": "Microsoft", "tag_type": "Company"},
+                    "Germany": {"name": "Germany", "tag_type": "Country"},
+                    "Berlin": {"name": "Berlin", "tag_type": "LOC"},
+                },
+                "news_items": [
+                    {
+                        "news_id": "offline-startup-test-news-1",
+                        "title": "Offline startup test headline",
+                        "content": "APT28 targeted Microsoft in Berlin, Germany.",
+                        "review": "",
+                        "language": "en",
+                    }
+                ],
+            }
+        ]
+    }
+
+    inference_response = client.post("/", json=payload)
+    assert inference_response.status_code == 200
+
+    response_json = inference_response.get_json()
+    assert isinstance(response_json, dict)
+    event_clusters = response_json.get("event_clusters")
+    if event_clusters is None:
+        event_clusters = response_json.get("cluster_ids", {}).get("event_clusters")
+
+    assert event_clusters
+    assert "offline-startup-test-story-1" in event_clusters[0]


### PR DESCRIPTION
## Summary
- add a new pytest that simulates a no-network environment during app startup
- force offline transformer/hf behavior via env vars to avoid remote lookups
- verify the app still starts, serves `/health`, and returns clustering results for a minimal request

## Validation
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --extra dev pytest -q tests/test_offline_startup.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --extra dev pytest -q`
